### PR TITLE
Correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ CodeMirror-Swift is a lightweight wrapper of CodeMirror for macOS and iOS.
 - ✅ 100% Native Swift 5 and modern WKWebView
 - 👑 Support iOS & macOS
 - 🎧 Built-in addons
-- 🔎 Customiziable (Addon, Themes, Modes...)
+- 🔎 Customizable (Addon, Themes, Modes...)
 - 📕 Dozen built-in themes and syntax highlight modes
 - ⚡️ Ready to go
 


### PR DESCRIPTION
🤓

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
